### PR TITLE
Side-scroller battle view, pixel-art avatars (transparent), remove grid animations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2025] [Kav Wang]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@
 - 遊戲狀態集中在 `state` 物件。事件綁定在開始時建立。
 
 祝玩得開心，練好乘法！
+
+## 視覺與戰鬥效果
+
+- 棋盤內效果：Canvas 2D 粒子/拋射物/飄字（`src/battle.js`）
+- 可選 Pixi 效果：動態載入，載入失敗不會中斷（`src/effects.js`）
+- 專用戰鬥畫面：16:9 Canvas 場景（`src/battleview.js`），顯示角色、攻擊、飄字與波紋
+
+### 美術素材建議來源（免授權或寬鬆授權）
+
+- Kenney.nl（CC0）: https://kenney.nl/assets
+- Game-Icons.net（CC BY 3.0）: https://game-icons.net/
+- OpenGameArt.org（多種授權）: https://opengameart.org/
+
+本專案預設使用自繪 SVG：`assets/hero.svg`, `assets/monster.svg`，無外部版權疑慮。你可替換成喜歡的圖片（PNG/SVG），檔名保持不變或調整 `src/battleview.js` 的載入路徑即可。

--- a/assets/hero-pixel.svg
+++ b/assets/hero-pixel.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="crispEdges">
+  
+  <!-- Hero body -->
+  <rect x="11" y="12" width="10" height="10" fill="#2b7fc0"/>
+  <rect x="12" y="22" width="8" height="4" fill="#2b7fc0"/>
+  <!-- Head -->
+  <rect x="12" y="6" width="8" height="6" fill="#f3c9a2"/>
+  <!-- Hair -->
+  <rect x="12" y="5" width="8" height="2" fill="#6b3f1f"/>
+  <rect x="11" y="6" width="2" height="2" fill="#6b3f1f"/>
+  <rect x="18" y="6" width="2" height="2" fill="#6b3f1f"/>
+  <!-- Eyes -->
+  <rect x="13" y="8" width="2" height="2" fill="#0d1b2a"/>
+  <rect x="17" y="8" width="2" height="2" fill="#0d1b2a"/>
+  <!-- Sword (big) -->
+  <rect x="21" y="9" width="9" height="2" fill="#c9d1d9"/>
+  <rect x="20" y="8" width="2" height="4" fill="#8b9aa8"/>
+  <rect x="19" y="10" width="1" height="2" fill="#d4a373"/>
+  <!-- Arms -->
+  <rect x="10" y="14" width="2" height="4" fill="#f3c9a2"/>
+  <rect x="20" y="14" width="2" height="3" fill="#f3c9a2"/>
+  <!-- Boots -->
+  <rect x="12" y="26" width="3" height="2" fill="#3a2d21"/>
+  <rect x="17" y="26" width="3" height="2" fill="#3a2d21"/>
+</svg>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#59d0ff"/>
+      <stop offset="1" stop-color="#2795c9"/>
+    </linearGradient>
+  </defs>
+  
+  <g transform="translate(64 66)">
+    <circle r="44" fill="url(#g)"/>
+    <circle r="44" fill="none" stroke="#ffffff" opacity=".06"/>
+    <circle cx="-16" cy="-8" r="7" fill="#fff"/>
+    <circle cx="16" cy="-8" r="7" fill="#fff"/>
+    <circle cx="-16" cy="-8" r="3.2" fill="#0e2130"/>
+    <circle cx="16" cy="-8" r="3.2" fill="#0e2130"/>
+    <path d="M -20 10 A 24 18 0 0 0 20 10" fill="none" stroke="#0e2130" stroke-width="6" stroke-linecap="round"/>
+    <path d="M -28 -20 C -12 -36, 12 -36, 28 -20" fill="none" stroke="#7be1ff" stroke-opacity=".6" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="-10" cy="-26" r="2" fill="#fff" opacity=".8"/>
+  </g>
+</svg>

--- a/assets/monster-pixel.svg
+++ b/assets/monster-pixel.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="crispEdges">
+  
+  <!-- Body -->
+  <rect x="8" y="10" width="16" height="14" fill="#ff6868"/>
+  <!-- Ears/Horns -->
+  <rect x="8" y="8" width="3" height="3" fill="#ffc0c0"/>
+  <rect x="21" y="8" width="3" height="3" fill="#ffc0c0"/>
+  <!-- Eyes -->
+  <rect x="12" y="14" width="3" height="3" fill="#fff"/>
+  <rect x="17" y="14" width="3" height="3" fill="#fff"/>
+  <rect x="13" y="15" width="1" height="1" fill="#2b0f0f"/>
+  <rect x="18" y="15" width="1" height="1" fill="#2b0f0f"/>
+  <!-- Mouth -->
+  <rect x="12" y="19" width="8" height="2" fill="#2b0f0f"/>
+  <rect x="13" y="19" width="1" height="1" fill="#fff"/>
+  <rect x="16" y="19" width="1" height="1" fill="#fff"/>
+  <rect x="19" y="19" width="1" height="1" fill="#fff"/>
+  <!-- Feet -->
+  <rect x="10" y="24" width="3" height="2" fill="#a33"/>
+  <rect x="19" y="24" width="3" height="2" fill="#a33"/>
+</svg>

--- a/assets/monster.svg
+++ b/assets/monster.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="m" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#ff7b7b"/>
+      <stop offset="1" stop-color="#d33a3a"/>
+    </linearGradient>
+  </defs>
+  
+  <g transform="translate(64 64)">
+    <circle r="46" fill="url(#m)"/>
+    <circle r="46" fill="none" stroke="#ffffff" opacity=".06"/>
+    <!-- horns -->
+    <path d="M -28 -30 C -36 -44, -18 -46, -12 -36" fill="#ffcdd2"/>
+    <path d="M 28 -30 C 36 -44, 18 -46, 12 -36" fill="#ffcdd2"/>
+    <!-- eyes -->
+    <ellipse cx="-15" cy="-6" rx="7" ry="9" fill="#fff"/>
+    <ellipse cx="15" cy="-6" rx="7" ry="9" fill="#fff"/>
+    <circle cx="-15" cy="-3" r="3.2" fill="#2b0f0f"/>
+    <circle cx="15" cy="-3" r="3.2" fill="#2b0f0f"/>
+    <!-- mouth -->
+    <path d="M -18 16 C -6 24, 6 24, 18 16" fill="none" stroke="#2b0f0f" stroke-width="6" stroke-linecap="round"/>
+    <path d="M -12 14 L -8 20 M -2 22 L 2 16 M 8 20 L 12 14" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
 				<div class="avatar" id="monsterAvatar">👾</div>
 				<div class="hp-bar"><div class="hp-fill" id="monsterHpFill" style="background:linear-gradient(90deg,var(--danger),#ff867f)"></div><div class="hp-text" id="monsterHpText"></div></div>
 			</div>
+			<!-- 專用戰鬥畫面區塊（16:9 Canvas） -->
+			<div class="card battle-view-card">
+				<div id="battleView" aria-label="戰鬥畫面"></div>
+			</div>
 		</div>
 		<div class="card" id="controls">
 			<div>

--- a/src/battle.js
+++ b/src/battle.js
@@ -1,0 +1,236 @@
+// Canvas 2D battle overlay (no external deps). Mobile-friendly with DPR scaling.
+let canvas = null, ctx = null, wrapper = null, ro = null, rafId = 0;
+let W = 0, H = 0, DPR = 1, DENSITY = 1;
+
+const particles = []; // {x,y,vx,vy,life,max, r, color}
+const projectiles = []; // {x,y,vx,vy,life,max, r, color, onHit}
+const floats = []; // {x,y,vy,life,max, text, color}
+const waves = []; // {x,y,r,vr,life,max,color,lineWidth}
+
+function computeDensity(){
+  let d = 1;
+  const ua = navigator.userAgent || '';
+  const isMobile = /Mobi|Android/i.test(ua);
+  const saveData = navigator.connection && navigator.connection.saveData;
+  const area = W*H;
+  if(isMobile) d *= 0.8;
+  if(saveData) d *= 0.7;
+  if(DPR > 1.5) d *= 0.85;
+  if(area < 220*220) d *= 0.8; // very small viewport
+  return Math.max(0.4, Math.min(1, d));
+}
+
+function resize(){
+  if(!wrapper || !canvas) return;
+  W = Math.max(1, wrapper.clientWidth);
+  H = Math.max(1, wrapper.clientHeight);
+  DPR = Math.min(window.devicePixelRatio || 1, 2);
+  canvas.width = Math.floor(W * DPR);
+  canvas.height = Math.floor(H * DPR);
+  canvas.style.width = W + 'px';
+  canvas.style.height = H + 'px';
+  if(ctx){ ctx.setTransform(DPR,0,0,DPR,0,0); }
+  DENSITY = computeDensity();
+}
+
+function loop(){
+  rafId = requestAnimationFrame(loop);
+  if(!ctx) return;
+  // fade clear
+  ctx.fillStyle = 'rgba(0,0,0,0)';
+  ctx.clearRect(0,0,W,H);
+
+  // update projectiles
+  for(let i=projectiles.length-1;i>=0;i--){
+    const p = projectiles[i];
+    p.x += p.vx; p.y += p.vy; p.life++;
+    ctx.fillStyle = p.color;
+    ctx.beginPath(); ctx.arc(p.x, p.y, p.r, 0, Math.PI*2); ctx.fill();
+    if(p.life>p.max){
+      projectiles.splice(i,1);
+      spawnBurst(p.x,p.y,p.color);
+      spawnShockwave(p.x,p.y,p.color, 1);
+      if(typeof p.onHit === 'function') p.onHit(p.x,p.y);
+    }
+  }
+
+  // update particles
+  for(let i=particles.length-1;i>=0;i--){
+    const p = particles[i];
+    p.x += p.vx; p.y += p.vy; p.vy += 0.15; p.life++;
+    const k = 1 - p.life/p.max;
+    ctx.globalAlpha = Math.max(0, k);
+    ctx.fillStyle = p.color; ctx.beginPath(); ctx.arc(p.x, p.y, p.r*k + 0.5, 0, Math.PI*2); ctx.fill();
+    ctx.globalAlpha = 1;
+    if(p.life>p.max) particles.splice(i,1);
+  }
+
+  // update shockwaves
+  for(let i=waves.length-1;i>=0;i--){
+    const w = waves[i];
+    w.r += w.vr; w.life++;
+    const k = 1 - w.life/w.max;
+    ctx.globalAlpha = Math.max(0, k*0.9);
+    ctx.strokeStyle = w.color;
+    ctx.lineWidth = Math.max(1, w.lineWidth * k);
+    ctx.beginPath(); ctx.arc(w.x, w.y, Math.max(0,w.r), 0, Math.PI*2); ctx.stroke();
+    ctx.globalAlpha = 1;
+    if(w.life>w.max) waves.splice(i,1);
+  }
+
+  // update floating texts
+  for(let i=floats.length-1;i>=0;i--){
+    const f = floats[i];
+    f.y += f.vy; f.life++;
+    const k = f.life/f.max;
+    ctx.globalAlpha = k<0.2 ? k*5 : 1-(k-0.2)/0.8;
+    ctx.fillStyle = f.color;
+    // Responsive font size: base 22px, scale with min(W,H)
+    const base = 22;
+    const scale = Math.max(0.9, Math.min(1.6, Math.min(W,H) / 360));
+    const fontPx = Math.round(base * scale);
+    ctx.font = `900 ${fontPx}px Segoe UI, Arial, sans-serif`;
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    // Stronger outline and soft glow for visibility
+    ctx.strokeStyle = '#111a26'; ctx.lineWidth = Math.max(3, Math.round(fontPx * 0.12));
+    ctx.shadowColor = 'rgba(0,0,0,0.6)';
+    ctx.shadowBlur = Math.round(fontPx * 0.25);
+    ctx.shadowOffsetX = 0; ctx.shadowOffsetY = 1;
+    ctx.strokeText(f.text, f.x, f.y);
+    ctx.fillText(f.text, f.x, f.y);
+    // reset shadow
+    ctx.shadowColor = 'transparent'; ctx.shadowBlur = 0;
+    ctx.globalAlpha = 1;
+    if(f.life>f.max) floats.splice(i,1);
+  }
+}
+
+function localPoint(el){
+  if(!wrapper) return {x:0,y:0};
+  const wr = wrapper.getBoundingClientRect();
+  const r = el.getBoundingClientRect();
+  return { x: (r.left + r.width/2) - wr.left, y: (r.top + r.height/2) - wr.top };
+}
+
+// Ensure a point is inside the canvas area; optionally bias by role for nicer placement
+function clampToCanvas(p, role){
+  let x = Math.max(10, Math.min(W - 10, p.x));
+  let y = Math.max(10, Math.min(H - 10, p.y));
+  // If the avatar is above the wrapper (negative y), bias to top/bottom bands
+  if(role === 'monster' && p.y < 0) y = Math.max(10, Math.min(H - 10, H * 0.15));
+  if(role === 'player' && p.y < 0) y = Math.max(10, Math.min(H - 10, H * 0.85));
+  return { x, y };
+}
+
+// Default in-canvas anchors when the source element is outside the wrapper
+function roleAnchor(role){
+  const margin = Math.max(10, Math.round(Math.min(W, H) * 0.05));
+  if(role === 'monster') return { x: Math.max(margin, Math.min(W - margin, W * 0.78)), y: Math.max(margin, Math.min(H - margin, H * 0.18)) };
+  // player
+  return { x: Math.max(margin, Math.min(W - margin, W * 0.22)), y: Math.max(margin, Math.min(H - margin, H * 0.82)) };
+}
+
+// Project an element's center into canvas space; if it's outside, use a role anchor
+function projectToCanvas(el, role){
+  if(!wrapper) return roleAnchor(role);
+  const wr = wrapper.getBoundingClientRect();
+  const r = el.getBoundingClientRect();
+  const outside = (r.right < wr.left) || (r.left > wr.right) || (r.bottom < wr.top) || (r.top > wr.bottom);
+  if(outside || W <= 1 || H <= 1) return roleAnchor(role);
+  return clampToCanvas({ x: (r.left + r.width/2) - wr.left, y: (r.top + r.height/2) - wr.top }, role);
+}
+
+function spawnBurst(x, y, color='#ffca28', count=12){
+  const n = Math.max(4, Math.round(count * DENSITY));
+  for(let i=0;i<n;i++){
+    const a = Math.random()*Math.PI*2;
+    const s = 2 + Math.random()*3;
+    particles.push({
+      x, y,
+      vx: Math.cos(a)*s,
+      vy: Math.sin(a)*s,
+      life: 0,
+      max: 24 + Math.floor(Math.random()*12),
+      r: 2 + Math.random()*2,
+      color
+    });
+  }
+}
+
+function spawnProjectile(x0,y0,x1,y1,color='#ffca28', onHit){
+  const dx=x1-x0, dy=y1-y0; const len=Math.max(1, Math.hypot(dx,dy));
+  const speed = 10; const vx = dx/len*speed; const vy = dy/len*speed;
+  const max = Math.ceil(len / speed);
+  projectiles.push({x:x0,y:y0,vx,vy,life:0,max,r:3,color,onHit});
+}
+
+function spawnShockwave(x,y,color='#ffffff', size=1){
+  const base = 10 * size;
+  waves.push({x,y,r: base*0.2, vr: 4+size*2, life:0, max: 24+size*10, color, lineWidth: 6*size});
+}
+
+export function initBattle(els){
+  if(canvas) return;
+  wrapper = document.getElementById('gridWrapper');
+  if(!wrapper) return;
+  canvas = document.createElement('canvas');
+  canvas.style.position = 'absolute';
+  canvas.style.inset = '0';
+  canvas.style.pointerEvents = 'none';
+  canvas.style.zIndex = '6';
+  // insert before overlay so overlay stays on top
+  const overlay = document.getElementById('overlayMessage');
+  if(overlay && overlay.parentElement===wrapper){ wrapper.insertBefore(canvas, overlay); } else { wrapper.appendChild(canvas); }
+  ctx = canvas.getContext('2d');
+  resize();
+  // Ensure a post-layout resize in case wrapper hasn't finalized dimensions yet
+  requestAnimationFrame(()=>{ resize(); });
+  if('ResizeObserver' in window){ ro = new ResizeObserver(resize); ro.observe(wrapper); } else { window.addEventListener('resize', resize); }
+  loop();
+}
+
+export function destroyBattle(){
+  if(ro && wrapper){ ro.unobserve(wrapper); ro = null; }
+  if(rafId){ cancelAnimationFrame(rafId); rafId=0; }
+  if(canvas && canvas.parentElement){ canvas.parentElement.removeChild(canvas); }
+  canvas = null; ctx = null; wrapper = null;
+  particles.length = 0; projectiles.length = 0; floats.length = 0;
+}
+
+export function battleSpawnAtElement(el, color='#ffca28'){
+  if(!canvas || !el) return;
+  const p = localPoint(el); spawnBurst(p.x, p.y, color, 12);
+}
+
+export function battleHeroAttack(els, combo=1, dmg){
+  if(!canvas) return;
+  // from playerAvatar center to monsterAvatar center
+  const p0 = projectToCanvas(els.playerAvatar, 'player');
+  const p1 = projectToCanvas(els.monsterAvatar, 'monster');
+  spawnProjectile(p0.x, p0.y, p1.x, p1.y, '#ffca28', (hx,hy)=>{
+    // on hit: bigger shockwave + damage float
+    spawnShockwave(hx,hy,'#ffca28', 1.2);
+    if(typeof dmg==='number') floats.push({x:hx, y:hy-18, vy:-0.7, life:0, max:52, text:`-${dmg}`, color:'#ffca28'});
+  });
+  // combo float near monster
+  floats.push({x:p1.x, y:p1.y-28, vy:-0.55, life:0, max:50, text:`x${combo}`, color:'#ffca28'});
+}
+
+export function battleMonsterAttack(els, dmg){
+  if(!canvas) return;
+  const p0 = projectToCanvas(els.monsterAvatar, 'monster');
+  const p1 = projectToCanvas(els.playerAvatar, 'player');
+  spawnProjectile(p0.x, p0.y, p1.x, p1.y, '#4caf50', (hx,hy)=>{
+    spawnShockwave(hx,hy,'#4caf50', 1.0);
+    if(typeof dmg==='number') floats.push({x:hx, y:hy-18, vy:-0.65, life:0, max:48, text:`-${dmg}`, color:'#4caf50'});
+  });
+}
+
+export function battleComboThreshold(els, combo){
+  if(!canvas || !combo) return;
+  if(combo % 5 !== 0) return;
+  const p = localPoint(els.monsterAvatar);
+  const size = combo % 10 === 0 ? 2.0 : 1.4;
+  spawnShockwave(p.x, p.y, '#ffd95e', size);
+  spawnBurst(p.x, p.y, '#ffd95e', Math.round(18 * size));
+}

--- a/src/battleview.js
+++ b/src/battleview.js
@@ -1,0 +1,228 @@
+// Dedicated battle view canvas renderer (no external assets):
+// Renders a simple scene with hero and monster, idle motion, attacks, damage/combo text.
+
+let root = null, canvas = null, ctx = null, ro = null, rafId = 0;
+let W = 0, H = 0, DPR = 1;
+
+const state = {
+  time: 0,
+  hero: { x: 0, y: 0, r: 40, color: '#4fc3f7' },
+  monster: { x: 0, y: 0, r: 46, color: '#ef5350' },
+  projectiles: [], // {x,y,vx,vy,life,max,color,r,onHit}
+  floats: [], // {x,y,vy,life,max,text,color,size}
+  waves: [], // {x,y,r,vr,life,max,color,lineWidth}
+};
+
+const imgs = { hero: null, monster: null };
+
+function placeActors(){
+  const pad = Math.max(24, Math.min(W,H)*0.06);
+  // side-scroller: hero left, monster right
+  state.hero.x = pad + state.hero.r + 8;
+  state.hero.y = H - pad - state.hero.r - 10;
+  state.monster.x = W - pad - state.monster.r - 8;
+  state.monster.y = pad + state.monster.r + 10;
+}
+
+function resize(){
+  if(!root || !canvas) return;
+  const r = root.getBoundingClientRect();
+  W = Math.max(1, Math.floor(r.width));
+  H = Math.max(1, Math.floor(r.height));
+  DPR = Math.min(window.devicePixelRatio || 1, 2);
+  canvas.width = Math.floor(W * DPR);
+  canvas.height = Math.floor(H * DPR);
+  canvas.style.width = W + 'px';
+  canvas.style.height = H + 'px';
+  if(ctx) ctx.setTransform(DPR,0,0,DPR,0,0);
+  placeActors();
+}
+
+function spawnProjectile(x0,y0,x1,y1,color='#ffca28', onHit){
+  const dx=x1-x0, dy=y1-y0; const len = Math.max(1, Math.hypot(dx,dy));
+  const speed = Math.max(6, Math.min(12, Math.sqrt(len)));
+  const vx = dx/len*speed, vy = dy/len*speed;
+  const max = Math.ceil(len / speed);
+  state.projectiles.push({x:x0,y:y0,vx,vy,life:0,max,color,r:3,onHit});
+}
+
+function spawnWave(x,y,color='#ffd95e', size=1){
+  const base = 10 * size;
+  state.waves.push({x,y,r:base*0.2,vr:4+size*2,life:0,max:24+size*10,color,lineWidth:6*size});
+}
+
+function addFloat(x,y,text,color='#ffca28', size=1){
+  const max = 52 + Math.floor(Math.random()*10);
+  state.floats.push({x,y,vy:-0.7,life:0,max,text,color,size});
+}
+
+export function bvHeroAttack(dmg, combo){
+  if(!ctx) return;
+  spawnProjectile(state.hero.x, state.hero.y, state.monster.x, state.monster.y, '#ffca28', (hx,hy)=>{
+    spawnWave(hx,hy,'#ffca28',1.2);
+    if(typeof dmg==='number') addFloat(hx, hy-18, `-${dmg}`, '#ffca28', 1.1);
+  });
+  addFloat(state.monster.x, state.monster.y-28, `x${combo}`, '#ffd95e', 1.0);
+}
+
+export function bvMonsterAttack(dmg){
+  if(!ctx) return;
+  spawnProjectile(state.monster.x, state.monster.y, state.hero.x, state.hero.y, '#4caf50', (hx,hy)=>{
+    spawnWave(hx,hy,'#4caf50',1.0);
+    if(typeof dmg==='number') addFloat(hx, hy-18, `-${dmg}`, '#4caf50', 1.0);
+  });
+}
+
+export function bvComboThreshold(combo){
+  if(!ctx) return;
+  if(combo % 5 !== 0) return;
+  const size = combo % 10 === 0 ? 1.8 : 1.2;
+  spawnWave(state.monster.x, state.monster.y, '#ffd95e', size);
+}
+
+export function initBattleView(){
+  if(canvas) return;
+  root = document.getElementById('battleView');
+  if(!root) return;
+  canvas = document.createElement('canvas');
+  root.appendChild(canvas);
+  ctx = canvas.getContext('2d');
+  // load images (SVG, pixel-art)
+  try {
+    const h = new Image(); h.decoding = 'async'; h.src = './assets/hero-pixel.svg'; h.onload = ()=>{ imgs.hero = h; };
+    const m = new Image(); m.decoding = 'async'; m.src = './assets/monster-pixel.svg'; m.onload = ()=>{ imgs.monster = m; };
+  } catch {}
+  resize();
+  requestAnimationFrame(resize);
+  if('ResizeObserver' in window){ ro = new ResizeObserver(resize); ro.observe(root); } else { window.addEventListener('resize', resize); }
+  loop();
+}
+
+export function destroyBattleView(){
+  if(ro && root){ ro.unobserve(root); ro = null; }
+  if(rafId){ cancelAnimationFrame(rafId); rafId = 0; }
+  if(canvas && canvas.parentElement) canvas.parentElement.removeChild(canvas);
+  canvas = null; ctx = null; root = null;
+  state.projectiles.length = 0; state.floats.length = 0; state.waves.length = 0;
+}
+
+function loop(){
+  rafId = requestAnimationFrame(loop);
+  if(!ctx) return;
+  // disable smoothing for pixel crisp
+  ctx.imageSmoothingEnabled = false;
+  state.time += 1;
+  // background: side-scroller mountains and ground
+  // sky gradient
+  const grad = ctx.createLinearGradient(0,0,0,H);
+  grad.addColorStop(0,'#0e1522'); grad.addColorStop(1,'#1a2740');
+  ctx.fillStyle = grad; ctx.fillRect(0,0,W,H);
+  // distant mountains (parallax)
+  const t = state.time * 0.3;
+  drawMountainLayer(0.18*H, '#233249', 0.4, t*0.3);
+  drawMountainLayer(0.32*H, '#1e2a3f', 0.6, t*0.5);
+  // ground strip
+  drawGround('#1c3526', '#2e5d3f');
+
+  // idle bob
+  const heroBob = Math.sin(state.time*0.06)*2;
+  const monBob = Math.cos(state.time*0.05)*2;
+
+  // draw actors first (so effects/text render on top)
+  drawActor(state.hero.x, state.hero.y + heroBob, state.hero.r, state.hero.color, '#1f2d3a', imgs.hero);
+  drawActor(state.monster.x, state.monster.y + monBob, state.monster.r, state.monster.color, '#3a1f1f', imgs.monster);
+
+  // projectiles
+  for(let i=state.projectiles.length-1;i>=0;i--){
+    const p = state.projectiles[i];
+    p.x += p.vx; p.y += p.vy; p.life++;
+    ctx.fillStyle = p.color; ctx.beginPath(); ctx.arc(p.x,p.y,p.r,0,Math.PI*2); ctx.fill();
+    if(p.life>p.max){
+      state.projectiles.splice(i,1);
+      spawnWave(p.x,p.y,p.color,1);
+      if(typeof p.onHit==='function') p.onHit(p.x,p.y);
+    }
+  }
+
+  // waves
+  for(let i=state.waves.length-1;i>=0;i--){
+    const w = state.waves[i]; w.r+=w.vr; w.life++;
+    const k = 1 - w.life/w.max; ctx.globalAlpha = Math.max(0, k*0.9);
+    ctx.strokeStyle = w.color; ctx.lineWidth = Math.max(1, w.lineWidth*k);
+    ctx.beginPath(); ctx.arc(w.x,w.y,Math.max(0,w.r),0,Math.PI*2); ctx.stroke();
+    ctx.globalAlpha = 1; if(w.life>w.max) state.waves.splice(i,1);
+  }
+
+  // floats (top-most)
+  for(let i=state.floats.length-1;i>=0;i--){
+    const f = state.floats[i]; f.y += f.vy; f.life++;
+    const k = f.life/f.max; ctx.globalAlpha = k<0.2 ? k*5 : 1-(k-0.2)/0.8;
+    const base = 22; const scale = Math.max(0.9, Math.min(1.6, Math.min(W,H)/360));
+    const px = Math.round(base*scale*f.size);
+    ctx.font = `900 ${px}px Segoe UI, Arial, sans-serif`;
+    ctx.textAlign='center'; ctx.textBaseline='middle';
+    ctx.strokeStyle = '#111a26'; ctx.lineWidth = Math.max(3, Math.round(px*0.12));
+    ctx.shadowColor = 'rgba(0,0,0,0.6)'; ctx.shadowBlur = Math.round(px*0.25); ctx.shadowOffsetX=0; ctx.shadowOffsetY=1;
+    ctx.fillStyle = f.color; ctx.strokeText(f.text,f.x,f.y); ctx.fillText(f.text,f.x,f.y);
+    ctx.shadowColor='transparent'; ctx.shadowBlur=0; ctx.globalAlpha=1;
+    if(f.life>f.max) state.floats.splice(i,1);
+  }
+  // end frame
+}
+
+function drawActor(x,y,r,fill,shadow,img){
+  ctx.save();
+  if(img && img.complete){
+    const size = r*2;
+    ctx.shadowColor = shadow; ctx.shadowBlur = Math.max(6, Math.round(r*0.7));
+    ctx.drawImage(img, Math.round(x-size/2), Math.round(y-size/2), Math.round(size), Math.round(size));
+    ctx.shadowBlur = 0; ctx.shadowColor = 'transparent';
+  } else {
+    ctx.shadowColor = shadow; ctx.shadowBlur = Math.max(4, Math.round(r*0.6));
+    ctx.fillStyle = fill; ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill();
+    ctx.shadowBlur = 0; ctx.shadowColor = 'transparent';
+    // simple face fallback
+    ctx.fillStyle = '#fff';
+    ctx.beginPath(); ctx.arc(x-r*0.35, y-r*0.15, r*0.12, 0, Math.PI*2); ctx.fill();
+    ctx.beginPath(); ctx.arc(x+r*0.35, y-r*0.15, r*0.12, 0, Math.PI*2); ctx.fill();
+    ctx.fillStyle = '#0f1a28';
+    ctx.beginPath(); ctx.arc(x-r*0.35, y-r*0.15, r*0.06, 0, Math.PI*2); ctx.fill();
+    ctx.beginPath(); ctx.arc(x+r*0.35, y-r*0.15, r*0.06, 0, Math.PI*2); ctx.fill();
+    ctx.strokeStyle = '#0f1a28'; ctx.lineWidth = Math.max(1, Math.round(r*0.12));
+    ctx.beginPath(); ctx.arc(x, y+r*0.15, r*0.4, 0.15*Math.PI, 0.85*Math.PI); ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawMountainLayer(h, color, scale, offset){
+  // draw a repeating triangular mountain range
+  const baseY = Math.floor(H*0.55 + h);
+  const width = Math.max(60, Math.floor(140*scale));
+  const amp = Math.max(20, Math.floor(50*scale));
+  const scroll = Math.floor(offset % width);
+  ctx.fillStyle = color;
+  // two passes to wrap
+  for(let pass=0; pass<2; pass++){
+    const start = -scroll + pass*width;
+    for(let x=start; x<W+width; x+=width){
+      ctx.beginPath();
+      ctx.moveTo(x, baseY);
+      ctx.lineTo(x + width*0.5, baseY - amp);
+      ctx.lineTo(x + width, baseY);
+      ctx.closePath();
+      ctx.fill();
+    }
+  }
+}
+
+function drawGround(dark, light){
+  const y = Math.floor(H*0.82);
+  // dark base
+  ctx.fillStyle = dark; ctx.fillRect(0, y, W, H - y);
+  // light ridges stripes
+  ctx.fillStyle = light;
+  const stripeH = 3; const gap = 6;
+  for(let yy = y + 6; yy < H; yy += (stripeH + gap)){
+    ctx.fillRect(0, yy, W, stripeH);
+  }
+}

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,6 +1,6 @@
 // Lightweight PixiJS overlay for battle effects (mobile-friendly)
-// ESM import from CDN to avoid bundler requirements
-import * as PIXI from 'https://unpkg.com/pixi.js@7.x/dist/pixi.mjs';
+// Dynamically import PixiJS from CDN so failures don't break the game
+let PIXI = null;
 
 let app = null;
 let root = null;
@@ -14,11 +14,14 @@ function resizeToWrapper(){
   app.renderer.resize(w, h);
 }
 
-export function initEffects(els){
+export async function initEffects(els){
   try{
     if(app) return; // already initialized
     wrapper = document.getElementById('gridWrapper');
     if(!wrapper) return;
+    if(!PIXI){
+      PIXI = await import('https://unpkg.com/pixi.js@7.x/dist/pixi.mjs');
+    }
     app = new PIXI.Application({
       width: wrapper.clientWidth || 300,
       height: wrapper.clientHeight || 300,

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,0 +1,176 @@
+// Lightweight PixiJS overlay for battle effects (mobile-friendly)
+// ESM import from CDN to avoid bundler requirements
+import * as PIXI from 'https://unpkg.com/pixi.js@7.x/dist/pixi.mjs';
+
+let app = null;
+let root = null;
+let wrapper = null;
+let ro = null; // ResizeObserver
+
+function resizeToWrapper(){
+  if(!app || !wrapper) return;
+  const w = Math.max(1, wrapper.clientWidth);
+  const h = Math.max(1, wrapper.clientHeight);
+  app.renderer.resize(w, h);
+}
+
+export function initEffects(els){
+  try{
+    if(app) return; // already initialized
+    wrapper = document.getElementById('gridWrapper');
+    if(!wrapper) return;
+    app = new PIXI.Application({
+      width: wrapper.clientWidth || 300,
+      height: wrapper.clientHeight || 300,
+      backgroundAlpha: 0,
+      antialias: true,
+      resolution: Math.min(window.devicePixelRatio || 1, 2), // cap for mobile perf
+      autoDensity: true,
+    });
+    root = new PIXI.Container();
+    app.stage.addChild(root);
+    const view = app.view;
+    view.style.position = 'absolute';
+    view.style.inset = '0';
+    view.style.pointerEvents = 'none';
+    view.style.zIndex = '5'; // keep UI overlay above
+    wrapper.style.position = wrapper.style.position || 'relative';
+    const overlayEl = document.getElementById('overlayMessage');
+    if(overlayEl && overlayEl.parentElement === wrapper){
+      wrapper.insertBefore(view, overlayEl);
+    } else {
+      wrapper.appendChild(view);
+    }
+    resizeToWrapper();
+    // Resize observer for responsiveness
+    if('ResizeObserver' in window){
+      ro = new ResizeObserver(()=> resizeToWrapper());
+      ro.observe(wrapper);
+    } else {
+      window.addEventListener('resize', resizeToWrapper);
+    }
+  }catch(e){
+    console.warn('initEffects failed', e);
+  }
+}
+
+function getLocalPoint(el){
+  if(!wrapper) return {x:0,y:0};
+  const wr = wrapper.getBoundingClientRect();
+  const r = el.getBoundingClientRect();
+  const x = (r.left + r.width/2) - wr.left;
+  const y = (r.top + r.height/2) - wr.top;
+  return {x, y};
+}
+
+function spawnBurst(x, y, color=0xffca28, count=10){
+  if(!app || !root) return;
+  const container = new PIXI.Container();
+  root.addChild(container);
+  const particles = [];
+  for(let i=0;i<count;i++){
+    const g = new PIXI.Graphics();
+    g.beginFill(color).drawCircle(0,0, 2+Math.random()*2).endFill();
+    g.x = x; g.y = y;
+    const angle = Math.random()*Math.PI*2;
+    const speed = 1 + Math.random()*2.5;
+    const life = 18 + Math.floor(Math.random()*12);
+    particles.push({g, vx: Math.cos(angle)*speed, vy: Math.sin(angle)*speed, life});
+    container.addChild(g);
+  }
+  let t = 0;
+  const tick = (delta)=>{
+    t += delta;
+    for(const p of particles){
+      p.g.x += p.vx * delta;
+      p.g.y += p.vy * delta;
+      p.vy += 0.05 * delta; // gravity
+      p.g.alpha = Math.max(0, 1 - (t/p.life));
+      p.g.scale.set(Math.max(0.2, 1 - (t/p.life)*0.5));
+    }
+    // cleanup
+    if(t > Math.max(...particles.map(p=>p.life))){
+      app.ticker.remove(tick);
+      container.destroy({children:true});
+    }
+  };
+  app.ticker.add(tick);
+}
+
+function screenShake(intensity=6, durationMs=150){
+  if(!app || !root) return;
+  const orig = {x: root.x, y: root.y};
+  let elapsed = 0;
+  const tick = (delta)=>{
+    elapsed += (delta/60)*1000; // approximate ms
+    if(elapsed >= durationMs){
+      root.position.set(orig.x, orig.y);
+      app.ticker.remove(tick);
+      return;
+    }
+    const k = 1 - (elapsed/durationMs);
+    root.x = (Math.random()*2-1) * intensity * k;
+    root.y = (Math.random()*2-1) * intensity * k;
+  };
+  app.ticker.add(tick);
+}
+
+export function playMatchBurstAtCell(cellEl){
+  if(!cellEl) return;
+  const {x,y} = getLocalPoint(cellEl);
+  spawnBurst(x, y, 0xffca28, 12);
+}
+
+export function playMonsterHit(els){
+  const el = els?.monsterAvatar || document.getElementById('monsterAvatar');
+  if(!el) return;
+  const {x,y} = getLocalPoint(el);
+  spawnBurst(x, y, 0xff5252, 16);
+  screenShake(8, 180);
+}
+
+export function playPlayerHit(els){
+  const el = els?.playerAvatar || document.getElementById('playerAvatar');
+  if(!el) return;
+  const {x,y} = getLocalPoint(el);
+  spawnBurst(x, y, 0x4caf50, 14);
+  screenShake(6, 160);
+}
+
+export function showCombo(n, nearEl){
+  if(!app || !root || !n) return;
+  const text = new PIXI.Text(`x${n}`, {
+    fontFamily: 'Segoe UI, Arial, sans-serif',
+    fontWeight: '800',
+    fontSize: 28,
+    fill: 0xffca28,
+    stroke: 0x1b2a38,
+    strokeThickness: 4,
+  });
+  let x= app.renderer.width/2, y = app.renderer.height*0.18;
+  if(nearEl){ const p = getLocalPoint(nearEl); x = p.x; y = p.y - 20; }
+  text.x = x; text.y = y; text.alpha = 0.0; text.anchor.set(0.5);
+  root.addChild(text);
+  let t = 0;
+  const dur = 40; // frames
+  const tick = (delta)=>{
+    t += delta;
+    const k = Math.min(1, t/dur);
+    text.alpha = k < 0.2 ? k*5 : 1 - (k-0.2)/0.8;
+    text.y = y - k*22;
+    text.scale.set(1 + Math.sin(k*Math.PI)*0.15);
+    if(k >= 1){
+      app.ticker.remove(tick);
+      text.destroy();
+    }
+  };
+  app.ticker.add(tick);
+}
+
+export function destroyEffects(){
+  try{
+    if(ro && wrapper) ro.unobserve(wrapper);
+    ro = null;
+    if(app){ app.destroy(true, {children:true}); app = null; root = null; wrapper = null; }
+  }catch{}
+}

--- a/src/game.js
+++ b/src/game.js
@@ -2,6 +2,7 @@ import { generateTriple, isValidTriple, countSolutionsFromCells, areAdjacent } f
 import { updateHpBars, log, updateSolutionCounter, clearHints, findOneSolution, ensureSolvableBoard } from './ui.js';
 import { initAudio, playSpawnSound } from './audio.js';
 import { initEffects, destroyEffects, playMatchBurstAtCell, playMonsterHit, playPlayerHit, showCombo } from './effects.js';
+import { initBattle, destroyBattle, battleSpawnAtElement, battleHeroAttack, battleMonsterAttack, battleComboThreshold } from './battle.js';
 
 export function createInitialState(){
   return {
@@ -161,6 +162,7 @@ export function attachGridHandlers(els, state){
         state.selected.forEach(c=>c.classList.add('match'));
         const matched = [...state.selected];
         try{ matched.forEach(c => playMatchBurstAtCell(c)); }catch{}
+        try{ matched.forEach(c => battleSpawnAtElement(c)); }catch{}
         performPlayerAttack(els, state, triple, matched.length);
         setTimeout(()=>{
           const idxs = matched.map(c=> parseInt(c.dataset.index,10));
@@ -190,6 +192,7 @@ export function performPlayerAttack(els, state, triple){
     setTimeout(()=>els.monsterAvatar && els.monsterAvatar.classList.remove('shake'),500);
   }
   try{ playMonsterHit(els); showCombo(state.combo, els.monsterAvatar); }catch{}
+  try{ battleHeroAttack(els, state.combo, dmg); battleComboThreshold(els, state.combo); }catch{}
   if(!checkEnd(els, state)){
     // placeholder for reward hooks
   }
@@ -205,6 +208,7 @@ export function monsterAttack(els, state){
     setTimeout(()=>els.playerAvatar && els.playerAvatar.classList.remove('shake'),500);
   }
   try{ playPlayerHit(els); }catch{}
+  try{ battleMonsterAttack(els, dmg); }catch{}
   checkEnd(els, state);
 }
 
@@ -216,6 +220,7 @@ export function startMonsterTimer(els, state){
 export function startGame(els, state){
   applyInputs(els, state); initGridStructure(els, state); initAudio();
   try{ initEffects(els); }catch{}
+  try{ initBattle(els); }catch{}
   fillAllCells(els);
   attachGridHandlers(els, state);
   ensureSolvableBoard(els, state, ()=>reshuffleBoard(els, state));
@@ -247,6 +252,7 @@ export function resetGame(els, state){
   if(els.solutionCounter) els.solutionCounter.textContent='-';
   log(els.log, '已重置。');
   try{ destroyEffects(); }catch{}
+  try{ destroyBattle(); }catch{}
 }
 
 export function bindGlobalButtons(els, state){

--- a/src/game.js
+++ b/src/game.js
@@ -3,6 +3,7 @@ import { updateHpBars, log, updateSolutionCounter, clearHints, findOneSolution, 
 import { initAudio, playSpawnSound } from './audio.js';
 import { initEffects, destroyEffects, playMatchBurstAtCell, playMonsterHit, playPlayerHit, showCombo } from './effects.js';
 import { initBattle, destroyBattle, battleSpawnAtElement, battleHeroAttack, battleMonsterAttack, battleComboThreshold } from './battle.js';
+import { initBattleView, destroyBattleView, bvHeroAttack, bvMonsterAttack, bvComboThreshold } from './battleview.js';
 
 export function createInitialState(){
   return {
@@ -82,10 +83,7 @@ export function collapseColumn(els, state, c){
     const triple = generateTriple();
     const v = triple[Math.floor(Math.random()*3)];
     cell.dataset.value = v; cell.textContent = v;
-    // animation + sound
-    cell.classList.add('spawn');
-    const onEnd = ()=>{ cell.classList.remove('spawn'); cell.removeEventListener('animationend', onEnd); };
-    cell.addEventListener('animationend', onEnd);
+    // sound only (spawn animation removed)
     playSpawnSound(520 - r*25);
   }
 }
@@ -170,7 +168,7 @@ export function attachGridHandlers(els, state){
           state.selected=[];
           applyGravity(els, state, idxs);
           updateSolutionCounter(els, state);
-        },450);
+        },120);
       } else {
         log(els.log, '不是有效的乘法組合。');
         setTimeout(()=>{ state.selected.forEach(c=>c.classList.remove('selected')); state.selected=[]; },400);
@@ -193,6 +191,7 @@ export function performPlayerAttack(els, state, triple){
   }
   try{ playMonsterHit(els); showCombo(state.combo, els.monsterAvatar); }catch{}
   try{ battleHeroAttack(els, state.combo, dmg); battleComboThreshold(els, state.combo); }catch{}
+  try{ bvHeroAttack(dmg, state.combo); bvComboThreshold(state.combo); }catch{}
   if(!checkEnd(els, state)){
     // placeholder for reward hooks
   }
@@ -209,6 +208,7 @@ export function monsterAttack(els, state){
   }
   try{ playPlayerHit(els); }catch{}
   try{ battleMonsterAttack(els, dmg); }catch{}
+  try{ bvMonsterAttack(dmg); }catch{}
   checkEnd(els, state);
 }
 
@@ -221,6 +221,7 @@ export function startGame(els, state){
   applyInputs(els, state); initGridStructure(els, state); initAudio();
   try{ initEffects(els); }catch{}
   try{ initBattle(els); }catch{}
+  try{ initBattleView(); }catch{}
   fillAllCells(els);
   attachGridHandlers(els, state);
   ensureSolvableBoard(els, state, ()=>reshuffleBoard(els, state));
@@ -253,6 +254,7 @@ export function resetGame(els, state){
   log(els.log, '已重置。');
   try{ destroyEffects(); }catch{}
   try{ destroyBattle(); }catch{}
+  try{ destroyBattleView(); }catch{}
 }
 
 export function bindGlobalButtons(els, state){

--- a/src/game.js
+++ b/src/game.js
@@ -1,6 +1,7 @@
 import { generateTriple, isValidTriple, countSolutionsFromCells, areAdjacent } from './utils.js';
 import { updateHpBars, log, updateSolutionCounter, clearHints, findOneSolution, ensureSolvableBoard } from './ui.js';
 import { initAudio, playSpawnSound } from './audio.js';
+import { initEffects, destroyEffects, playMatchBurstAtCell, playMonsterHit, playPlayerHit, showCombo } from './effects.js';
 
 export function createInitialState(){
   return {
@@ -159,6 +160,7 @@ export function attachGridHandlers(els, state){
         log(els.log, `成功: ${triple.a} x ${triple.b} = ${triple.c}`);
         state.selected.forEach(c=>c.classList.add('match'));
         const matched = [...state.selected];
+        try{ matched.forEach(c => playMatchBurstAtCell(c)); }catch{}
         performPlayerAttack(els, state, triple, matched.length);
         setTimeout(()=>{
           const idxs = matched.map(c=> parseInt(c.dataset.index,10));
@@ -187,6 +189,7 @@ export function performPlayerAttack(els, state, triple){
     els.monsterAvatar.classList.add('shake');
     setTimeout(()=>els.monsterAvatar && els.monsterAvatar.classList.remove('shake'),500);
   }
+  try{ playMonsterHit(els); showCombo(state.combo, els.monsterAvatar); }catch{}
   if(!checkEnd(els, state)){
     // placeholder for reward hooks
   }
@@ -201,6 +204,7 @@ export function monsterAttack(els, state){
     els.playerAvatar.classList.add('shake');
     setTimeout(()=>els.playerAvatar && els.playerAvatar.classList.remove('shake'),500);
   }
+  try{ playPlayerHit(els); }catch{}
   checkEnd(els, state);
 }
 
@@ -211,6 +215,7 @@ export function startMonsterTimer(els, state){
 
 export function startGame(els, state){
   applyInputs(els, state); initGridStructure(els, state); initAudio();
+  try{ initEffects(els); }catch{}
   fillAllCells(els);
   attachGridHandlers(els, state);
   ensureSolvableBoard(els, state, ()=>reshuffleBoard(els, state));
@@ -241,6 +246,7 @@ export function resetGame(els, state){
   clearHints(els, state);
   if(els.solutionCounter) els.solutionCounter.textContent='-';
   log(els.log, '已重置。');
+  try{ destroyEffects(); }catch{}
 }
 
 export function bindGlobalButtons(els, state){

--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,13 @@ button {cursor:pointer; font-weight:600; letter-spacing:1px;}
 button.primary {background:var(--accent); color:#222; border-color:#e9b114;}
 button.primary:active {transform:translateY(1px);}    
 #log {max-width:420px; max-height:130px; overflow:auto; font-size:.7rem; background:var(--panel); padding:.4rem .6rem; border-radius:8px; line-height:1.2;}
-#battleArea {display:flex; gap:1.5rem; justify-content:center; flex-wrap:wrap; margin-top:.5rem;}
+#battleArea {display:flex; gap:1rem; justify-content:center; align-items:flex-start; flex-wrap:wrap; margin-top:.5rem;}
+
+/* Battle View block */
+.battle-view-card {margin-top: 0; width:min(640px, 82vw);} 
+#battleView {position: relative; width:100%; aspect-ratio:16/9; background:linear-gradient(180deg,#0f1a28,#152840); border-radius:12px; overflow:hidden; box-shadow:inset 0 0 30px rgba(0,0,0,.35);} 
+#battleView canvas {position:absolute; inset:0; width:100%; height:100%;}
+#battleView canvas {image-rendering: pixelated; image-rendering: crisp-edges;}
 
 /* Grid */
 #gridWrapper {margin-top:1rem; background:var(--panel); padding:1rem; border-radius:20px; width:var(--grid-size); max-width:92vw; aspect-ratio:1/1; display:flex; align-items:center; justify-content:center; box-shadow:0 6px 20px rgba(0,0,0,.55); position:relative;}
@@ -32,11 +38,11 @@ button.primary:active {transform:translateY(1px);}
 .cell {background:#22405c; border-radius:10px; display:flex; align-items:center; justify-content:center; font-size:clamp(.8rem,3.2vmin,1.6rem); font-weight:600; user-select:none; cursor:pointer; position:relative; transition:transform .15s, background .25s, box-shadow .25s; box-shadow:0 2px 4px rgba(0,0,0,.4);}    
 .cell:hover {background:#2c5679;}
 .cell.selected {background:#ffca28; color:#1b2a38; box-shadow:0 0 0 3px #ffd95e, 0 4px 10px rgba(0,0,0,.6);}
-.cell.match {animation:popOut .5s forwards;}
+.cell.match {animation:none;}
 .cell.hint {outline:3px solid #ff5252; box-shadow:0 0 6px 3px rgba(255,82,82,.55);} 
 .cell.falling {transition: transform .18s ease-out;}
 /* 新生成方塊自上方掉入動畫 */
-.cell.spawn {animation: dropIn .22s ease-out forwards; transform: translateY(-120%);} 
+.cell.spawn {animation:none; transform:none;}
 @keyframes dropIn { from { transform: translateY(-120%); opacity: .9;} to { transform: translateY(0); opacity: 1; } }
 @keyframes popOut {0%{transform:scale(1);} 60%{transform:scale(1.25) rotate(5deg);} 100%{transform:scale(0) rotate(-12deg); opacity:0;}}
 .shake {animation:shake .5s;} @keyframes shake {10%,90%{transform:translateX(-2px);} 20%,80%{transform:translateX(4px);} 30%,50%,70%{transform:translateX(-6px);} 40%,60%{transform:translateX(6px);}}
@@ -48,4 +54,5 @@ button.primary:active {transform:translateY(1px);}
   .avatar {width:60px; height:60px; font-size:1.5rem;}
   .hp-bar {width:120px;}
   #battleArea {gap:.75rem;}
+  .battle-view-card {width: 90vw;}
 }


### PR DESCRIPTION
新增

- 專用戰鬥畫面（[battleview.js](vscode-file://vscode-app/c:/Users/10008041/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)）：英雄(左) vs 怪物(右) 橫向卷軸風格；天空漸層、山脈視差、地面條紋背景；投射物、命中波紋、傷害/Combo 飄字（最上層）；支援 DPI 縮放與像素風（imageSmoothing 關閉 + CSS image-rendering）。
- 像素風角色 SVG（透明底）：[hero-pixel.svg](vscode-file://vscode-app/c:/Users/10008041/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [monster-pixel.svg](vscode-file://vscode-app/c:/Users/10008041/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)；同時保留一組矢量風 SVG（透明底）。

調整

- 將 #battleView 放入 #battleArea，縮窄戰鬥畫面寬度，整體視覺更集中。
- 移除棋盤數字動畫，改由戰鬥畫面承擔主要演出；縮短配對後延遲提升節奏。
- 飄字渲染順序置頂，避免被角色圖遮擋。

文件

- README 更新使用說明、素材替換與快速啟動指引。

影響範圍

- index.html, styles.css, src/battleview.js, src/game.js, assets/*